### PR TITLE
DO-NOT-MERGE: Minify HTML templates

### DIFF
--- a/email.class.php
+++ b/email.class.php
@@ -196,6 +196,7 @@ class Email {
         $mail->SetFrom($email_from, $from_name_encoded);
         $mail->Subject = $subject;
         $mail->AltBody = $message;
+        $html_message = preg_replace('/\s+/', ' ', $html_message);
         $mail->MsgHTML($html_message);
         $mail->CharSet = 'UTF-8';
 

--- a/email.class.php
+++ b/email.class.php
@@ -318,14 +318,19 @@ class Email {
     }
 
     private function _parse_templates($template){
-        if (!(function_exists('get_language_json') && function_exists('visitor_language'))) {
+        if (!(function_exists('get_language_json') && function_exists('visitor_language') && function_exists('get_app_settings'))) {
             return $template;
         }
-            
-        $replacement   = array();
-        $language_json = json_decode(get_language_json(visitor_language()));
 
-        foreach($language_json->texts as $key=>$value){
+        $replacements = array();    
+        $language_json = json_decode(get_language_json(visitor_language()));
+        $app_settings    = (array) get_app_settings();
+        if (!empty($app_settings["router_paths"])) {
+            unset($app_settings["router_paths"]);
+        }
+        $language_json->texts = (object) array_merge((array) $language_json->texts, $app_settings);
+        
+        foreach ($language_json->texts as $key=>$value) {
             $replacements[$key] = $value;
         }
 
@@ -337,7 +342,6 @@ class Email {
                 $template = preg_replace("#[']*\[%" . $key . "%\][']*#", $replacement, $template);
             } 
         }
-       
 
         return $template;
     }

--- a/email.class.php
+++ b/email.class.php
@@ -329,12 +329,15 @@ class Email {
             $replacements[$key] = $value;
         }
 
-        foreach($replacements as $key=>$value) {
-            $replacement = isset($value) ? $value : "";
+        while (strpos($template), '[%') {
+            foreach($replacements as $key=>$value) {
+                $replacement = isset($value) ? $value : "";
 
-            $template = preg_replace("#[']*<%" . $key . "%>[']*#", json_encode($replacement), $template);
-            $template = preg_replace("#[']*\[%" . $key . "%\][']*#", $replacement, $template);
+                $template = preg_replace("#[']*<%" . $key . "%>[']*#", json_encode($replacement), $template);
+                $template = preg_replace("#[']*\[%" . $key . "%\][']*#", $replacement, $template);
+            } 
         }
+       
 
         return $template;
     }

--- a/email.class.php
+++ b/email.class.php
@@ -329,7 +329,7 @@ class Email {
             $replacements[$key] = $value;
         }
 
-        while (strpos($template), '[%') {
+        while (strpos($template, '[%')) {
             foreach($replacements as $key=>$value) {
                 $replacement = isset($value) ? $value : "";
 

--- a/email.class.php
+++ b/email.class.php
@@ -200,6 +200,7 @@ class Email {
         $mail->SetFrom($email_from, $from_name_encoded);
         $mail->Subject = $subject;
         $mail->AltBody = $message;
+        //NOTE: After updating on php.mailer > 6 check if this is still necessary
         $html_message = preg_replace('/\s+/', ' ', $html_message);
         $mail->MsgHTML($html_message);
         $mail->CharSet = 'UTF-8';


### PR DESCRIPTION
1. Why is this change necessary?
There's a limit with the number of characters accepted per line in
an email as seen in https://code.djangoproject.com/ticket/22561.

PHPMailer claims it can wrap the lines and such, but it fails in an
unpredictable way and tries to switch to 'quoted-printable' encoding
when appropriate.

There's work going in the v6 branch of PHPMailer to tackle this. But
meanwhile minifying the HTML and throwing it to the library seems to
circumvent the issue.

As such this is just a temporary fix so we tell composer to require
from this branch, meanwhile we await official release